### PR TITLE
fix: invalid TERM inside tmux causing nvim rendering glitches

### DIFF
--- a/neovim/lua/settings/options.lua
+++ b/neovim/lua/settings/options.lua
@@ -9,7 +9,6 @@ local options = {
   hlsearch = true,
   undolevels = 1000,
   history = 1000,
-  lazyredraw = true,
   clipboard = "unnamedplus",
   shiftwidth = 2,
   tabstop = 2,

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -16,8 +16,10 @@ set-option -g pane-base-index 1
 # navigate using vim
 setw -g mode-keys vi
 
-# allow terminal scrolling
-set -g terminal-overrides ",xterm-256color:Tc"
+set -g default-terminal "tmux-256color"
+
+# advertise true color support (kitty's TERM is xterm-kitty)
+set -as terminal-overrides ",xterm*:Tc"
 
 # split panes using v and s
 bind v split-window -h
@@ -54,7 +56,6 @@ bind -n M-Down select-pane -D
 # Allow mouse to select which pane to use
 set -g mouse on
 
-set -g default-terminal "xterm-256-color"
 setw -g xterm-keys on
 bind-key -n S-Up set-option -g status
 bind-key -n S-Down set-option -g status


### PR DESCRIPTION
## Problem
Neovim inside tmux wasn't rendering lines/text properly — the screen only fixed itself after resizing the window or changing font size.

## Root cause
`.tmux.conf` set `default-terminal "xterm-256-color"` — note the extra hyphen. That terminfo entry does not exist (`infocmp xterm-256-color` fails), so every program inside tmux ran with a broken `TERM` and couldn't negotiate escape sequences correctly. A resize forces a full redraw, which is why that "fixed" it.

Two contributing issues:
- The `Tc` (true color) override only matched `xterm-256color`, but kitty's TERM is `xterm-kitty`, so it never applied.
- Neovim had `lazyredraw = true`, a documented cause of stale-screen artifacts.

## Fix
- Set `default-terminal "tmux-256color"` (verified present in terminfo) and remove the duplicate invalid line
- Widen the true-color override to `xterm*` so it matches `xterm-kitty`
- Remove `lazyredraw` from neovim options

## Verification
- `tmux -f .tmux.conf` loads with no errors on tmux 3.7a; `default-terminal` resolves to `tmux-256color`
- Edited lua file runs cleanly in headless nvim

After merging: restart tmux fully (`tmux kill-server`) — a config reload won't change `TERM` in existing panes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)