### PR TITLE
fix: don't clobber TERM inside tmux from zsh env

### DIFF
--- a/zsh/env.zsh
+++ b/zsh/env.zsh
@@ -5,7 +5,8 @@ export PATH="/bin:$PATH"
 export PATH="/usr/local/opt/docker-virtualbox/bin:$PATH"
 
 # Shell
-export TERM="xterm-256color"
+# don't clobber TERM inside tmux — tmux sets tmux-256color itself
+[ -z "$TMUX" ] && export TERM="xterm-256color"
 export EDITOR='nvim'
 
 # oh-my-zsh


### PR DESCRIPTION
Follow-up to #5. `zsh/env.zsh` unconditionally exported `TERM=xterm-256color`, overriding the `tmux-256color` that tmux sets for its panes — so nvim ran with terminfo that doesn't match what tmux implements, masking the #5 fix entirely. This guards the export with `[ -z "$TMUX" ]`: outside tmux it still normalizes kitty's `xterm-kitty` (useful for ssh to hosts without kitty terminfo), inside tmux the correct `tmux-256color` now survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)