### PR TITLE
fix: disable nvim termsync to stop dropped frames in tmux

### DIFF
--- a/neovim/lua/settings/options.lua
+++ b/neovim/lua/settings/options.lua
@@ -21,6 +21,9 @@ local options = {
   -- display --
   synmaxcol = 128,
   termguicolors = true,
+  -- tmux's synchronized-output buffering drops frames (blank floats until
+  -- a forced repaint), so don't emit sync markers
+  termsync = false,
   -- line numbers --
   rnu = true,
   nu = true,


### PR DESCRIPTION
Third and final piece of the rendering saga (#5, #6). With TERM plumbing fixed, Telescope floats were still blank until a pane switch forced tmux to repaint. Root cause: nvim 0.10+ wraps redraws in synchronized-output markers (DEC mode 2026); tmux advertises support and buffers the frames internally (the outer terminal path reports `Sync: [missing]`), and the final frame gets held. Verified interactively: `:set notermsync` fixes the rendering immediately. This makes it permanent. Cost is only nvim's anti-tearing frame batching, which tmux was mishandling anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)